### PR TITLE
ERA5: Don't crash if the column we try to drop doesn't exist

### DIFF
--- a/metocean_api/ts/read_ec.py
+++ b/metocean_api/ts/read_ec.py
@@ -36,7 +36,7 @@ def era5_ts(self, save_csv=False, save_nc=False):
                 save_csv=False,
                 height=self.height,
             )
-            df.drop(columns=['number', 'expver'], inplace=True)
+            df.drop(columns=['number', 'expver'], inplace=True, errors='ignore')
             variable = df.columns[0]
             try:
                 standard_name = ds[variable].standard_name


### PR DESCRIPTION
I had an issue. Sometimes the 'expver' column does not exist in the data set. 
In that case trying to drop the column would result in a crash. 
This is fixed by passing errors='ignore' to the drop method. 