### PR TITLE
Add CODEOWNER file to reduce reviewer list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This is a comment line
+# Each line follows the format: path pattern  @username or @team-name
+
+# Global rule:
+*   @KonstantinChri


### PR DESCRIPTION
To reduce the scope of reviewers it is possible to use a CODEOWNER file. 
See https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners