### PR TITLE
Adding API for NORAC and NORA3 wave spectra timeseries

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -132,6 +132,14 @@ Several options for **product** are available. Please check the data catalog for
 
   Dataset: https://thredds.met.no/thredds/catalog/stormrisk/catalog.html
 
+* For wave spectra from NORA3 (Nordic Seas) developed by MET Norway: 
+
+  .. code-block:: python
+
+    product='NORA3_wave_spec'
+
+  Dataset: https://thredds.met.no/thredds/catalog/windsurfer/mywavewam3km_spectra/catalog.html
+
 * For coastal wave NORA3 data developed by MET Norway: 
 
   .. code-block:: python
@@ -139,6 +147,14 @@ Several options for **product** are available. Please check the data catalog for
     product='NORAC_wave'
 
   Dataset: https://thredds.met.no/thredds/catalog/norac_wave/field/catalog.html
+
+* For coastal wave spectra (Norwegian coast) developed by MET Norway: 
+
+  .. code-block:: python
+    
+    product='NORAC_wave_spec'
+
+  Dataset: https://thredds.met.no/thredds/catalog/norac_wave/spec/catalog.html
 
 * For ocean data (sea level, temperature, currents, salinity over depth ) Norkyst800 data (from 2016-09-14 to today) developed by MET Norway: 
 

--- a/metocean_api/ts/read_metno.py
+++ b/metocean_api/ts/read_metno.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import os
 import xarray as xr
 import numpy as np
+import pandas as pd
 from .aux_funcs import (
     get_dates,
     get_url_info,
@@ -590,6 +591,112 @@ def obs_e39(ts: TimeSeries, save_csv=False, save_nc=False, use_cache=False):
     print("Data saved at: " + ts.datafile)
 
     return df
+
+def nora3_wave_spec(ts: TimeSeries, save_csv=False, save_nc=False, use_cache=False):
+    """
+    Extract NORA3 wave spectra timeseries.
+    """
+    ts.variable.append("longitude")  # keep info of regular lon
+    ts.variable.append("latitude")  # keep info of regular lat
+    dates = get_dates(ts.product, ts.start_time, ts.end_time)
+    tempfiles = get_tempfiles(ts.product, ts.lon, ts.lat, dates)
+
+    selection = None
+    lon_near = None
+    lat_near = None
+
+    # extract point and create temp files
+    for i in range(len(dates)):
+        url = get_url_info(ts.product, dates[i])
+
+        if i == 0:
+            station, lon_near, lat_near = get_near_coord(
+                url, ts.lon, ts.lat, ts.product
+            )
+
+        if use_cache and os.path.exists(tempfiles[i]):
+            print(f"Found cached file {tempfiles[i]}. Using this instead")
+        else:
+            with xr.open_dataset(url) as dataset:
+                # Reduce to the wanted variables and coordinates
+                dataset = dataset[ts.variable]
+                dataset = dataset.sel(station).squeeze(drop=True)
+                dataset.to_netcdf(tempfiles[i])
+
+    __remove_if_datafile_exists(ts.datafile)
+    # merge temp files and create combined result
+    with xr.open_mfdataset(tempfiles) as ds:
+        da = ds["SPEC"]
+        da.attrs["longitude"] = float(ds["longitude"][0].values)
+        da.attrs["latitude"] = float(ds["latitude"][0].values)
+    
+    if save_csv:
+        s = da.shape
+        csv_data = {"time": da["time"].values.repeat(s[1]*s[2]),
+            "frequency": np.tile(da["freq"].values.repeat(s[2]),s[0]),
+            "direction": np.tile(da["direction"].values,s[0]*s[1]),
+            "value": da.values.flatten()}
+        csv_data = pd.DataFrame(csv_data,columns=["time","frequency","direction","value"])
+        csv_data.to_csv(ts.datafile,index=False)
+    
+    if save_nc:
+        # Save the unaltered structure
+        da.to_netcdf(ts.datafile.replace(".csv", ".nc"))
+
+    return da
+
+def norac_wave_spec(ts: TimeSeries, save_csv=False, save_nc=False, use_cache=False) -> xr.DataArray:
+    """
+    Extract NORAC wave spectra timeseries.
+    """
+    ts.variable.append("longitude")  # keep info of regular lon
+    ts.variable.append("latitude")  # keep info of regular lat
+    dates = get_dates(ts.product, ts.start_time, ts.end_time)
+    tempfiles = get_tempfiles(ts.product, ts.lon, ts.lat, dates)
+
+    selection = None
+    lon_near = None
+    lat_near = None
+
+    # extract point and create temp files
+    for i in range(len(dates)):
+        url = get_url_info(ts.product, dates[i])
+
+        if i == 0:
+            station, lon_near, lat_near = get_near_coord(
+                url, ts.lon, ts.lat, ts.product
+            )
+
+        if use_cache and os.path.exists(tempfiles[i]):
+            print(f"Found cached file {tempfiles[i]}. Using this instead")
+        else:
+            with xr.open_dataset(url) as dataset:
+                # Reduce to the wanted variables and coordinates
+                dataset = dataset[ts.variable]
+                dataset = dataset.sel(station).squeeze(drop=True)
+                dataset.to_netcdf(tempfiles[i])
+
+    __remove_if_datafile_exists(ts.datafile)
+    # merge temp files and create combined result
+    with xr.open_mfdataset(tempfiles) as ds:
+        da = ds["efth"]
+        da.attrs["longitude"] = float(ds["longitude"][0].values)
+        da.attrs["latitude"] = float(ds["latitude"][0].values)
+
+    if save_csv:
+        s = da.shape
+        csv_data = {"time": da["time"].values.repeat(s[1]*s[2]),
+            "frequency": np.tile(da["frequency"].values.repeat(s[2]),s[0]),
+            "direction": np.tile(da["direction"].values,s[0]*s[1]),
+            "value": da.values.flatten()}
+        csv_data = pd.DataFrame(csv_data,columns=["time","frequency","direction","value"])
+        csv_data.to_csv(ts.datafile,index=False)
+            
+    if save_nc:
+        # Save the unaltered structure
+        da.to_netcdf(ts.datafile.replace(".csv", ".nc"))
+    
+    return da
 
 
 def __clean_cache(tempfiles):

--- a/metocean_api/ts/ts_mod.py
+++ b/metocean_api/ts/ts_mod.py
@@ -214,6 +214,12 @@ class TimeSeries:
         elif self.product == 'ECHOWAVE':
             self.variable = [ 'ucur', 'vcur', 'uwnd', 'vwnd', 'wlv', 'ice', 'hs', 'lm', 't02', 't01', 'fp', 'dir', 'spr', 'dp', 'phs0', 'phs1', 'phs2', 'ptp0', 'ptp1', 'ptp2', 'pdir0', 'pdir1']
             self.data = tudelft.echowave_ts(self, save_csv, save_nc, use_cache)
+        elif self.product == 'NORA3_SPEC':
+            self.variable = ['SPEC']
+            self.data = metno.nora3_spec(self,save_csv,save_nc,use_cache)
+        elif self.product == 'NORAC_SPEC':
+            self.variable = ['efth']
+            self.data = metno.norac_spec(self,save_csv,save_nc,use_cache)
 
         return
 

--- a/metocean_api/ts/ts_mod.py
+++ b/metocean_api/ts/ts_mod.py
@@ -214,13 +214,14 @@ class TimeSeries:
         elif self.product == 'ECHOWAVE':
             self.variable = [ 'ucur', 'vcur', 'uwnd', 'vwnd', 'wlv', 'ice', 'hs', 'lm', 't02', 't01', 'fp', 'dir', 'spr', 'dp', 'phs0', 'phs1', 'phs2', 'ptp0', 'ptp1', 'ptp2', 'pdir0', 'pdir1']
             self.data = tudelft.echowave_ts(self, save_csv, save_nc, use_cache)
-        elif self.product == 'NORA3_SPEC':
+        elif self.product == 'NORA3_wave_spec':
             self.variable = ['SPEC']
-            self.data = metno.nora3_spec(self,save_csv,save_nc,use_cache)
-        elif self.product == 'NORAC_SPEC':
+            self.data = metno.nora3_wave_spec(self,save_csv,save_nc,use_cache)
+        elif self.product == 'NORAC_wave_spec':
             self.variable = ['efth']
-            self.data = metno.norac_spec(self,save_csv,save_nc,use_cache)
-
+            self.data = metno.norac_wave_spec(self,save_csv,save_nc,use_cache)
+        else:
+            raise ValueError("Product not found.")
         return
 
     def load_data(self, local_file):

--- a/tests/test_extract_data.py
+++ b/tests/test_extract_data.py
@@ -60,3 +60,15 @@ def test_echowave():
     # Import data from https://data.4tu.nl/datasets/
     df_ts.import_data(save_csv=False,save_nc=False)
     assert df_ts.data.shape == (48, 22)
+
+def test_extract_nora3_spectra():
+    df_ts = ts.TimeSeries(lon=3.73, lat=64.60,start_time='2017-01-01',end_time='2017-01-20',product='NORA3_SPEC')
+    # Import data from thredds.met.no
+    df_ts.import_data(save_csv=False,save_nc=False)
+    assert df_ts.data.shape == (480,30,24)
+    
+def test_extract_norac_spectra():
+    df_ts = ts.TimeSeries(lon=3.73, lat=64.60,start_time='2017-01-01',end_time='2017-01-20',product='NORAC_SPEC')
+    # Import data from thredds.met.no
+    df_ts.import_data(save_csv=False,save_nc=False)
+    assert df_ts.data.shape == (744,45,36)

--- a/tests/test_extract_data.py
+++ b/tests/test_extract_data.py
@@ -61,14 +61,14 @@ def test_echowave():
     df_ts.import_data(save_csv=False,save_nc=False)
     assert df_ts.data.shape == (48, 22)
 
-def test_extract_nora3_spectra():
-    df_ts = ts.TimeSeries(lon=3.73, lat=64.60,start_time='2017-01-01',end_time='2017-01-20',product='NORA3_SPEC')
+def test_extract_nora3_wave_spectra():
+    df_ts = ts.TimeSeries(lon=3.73, lat=64.60,start_time='2017-01-29',end_time='2017-02-02',product='NORA3_wave_spec')
     # Import data from thredds.met.no
     df_ts.import_data(save_csv=False,save_nc=False)
-    assert df_ts.data.shape == (480,30,24)
+    assert df_ts.data.shape == (120,30,24)
     
-def test_extract_norac_spectra():
-    df_ts = ts.TimeSeries(lon=3.73, lat=64.60,start_time='2017-01-01',end_time='2017-01-20',product='NORAC_SPEC')
+def test_extract_norac_wave_spectra():
+    df_ts = ts.TimeSeries(lon=8, lat=64,start_time='2017-01-01',end_time='2017-01-04',product='NORAC_wave_spec')
     # Import data from thredds.met.no
     df_ts.import_data(save_csv=False,save_nc=False)
     assert df_ts.data.shape == (744,45,36)


### PR DESCRIPTION
New products added, including tests:
* "NORA3_wave_spec" (https://thredds.met.no/thredds/catalog/windsurfer/mywavewam3km_spectra/catalog.html)
* "NORAC_wave_spec" (https://thredds.met.no/thredds/catalog/norac_wave/spec/catalog.html)

I implemented the option of saving spectra to .csv in a "panel" data format, although it is very inefficient compared to using NetCDF .nc files due to the multidimensional spectra data.