### PR TITLE
Fix for coverage report upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.os }}-${{ matrix.python-version }}
-          path: htmlcov
+          path: htmlcov   # This is the default directory where the HTML report is generated
 
 
       - name: Build wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: html-coverage-report
-          path: htmlcov  # This is the default directory where the HTML report is generated
+          name: coverage-report-${{ matrix.os }}-${{ matrix.python-version }}
+          path: htmlcov
 
 
       - name: Build wheels


### PR DESCRIPTION
This pull request updates the test workflow to remove the error caused by the upload of the coverage report. The fix names the coverage report according to the OS and Python version from the matrix.