### PR TITLE
Adding a CLI for metocean-api to be used directly in command line

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -281,11 +281,13 @@ Command Line Interface (CLI) - metocean-cli
 
   The ``download`` command is used to download metocean data for a specified product, location, and time range.
 
+  By default, we are using the existing cached data, if you want to ignore the cached data (product change, redownload...) please use ``--no_cache``
+
   **Usage:**
 
   .. code-block:: bash
 
-    metocean-cli download <product> <lat> <lon> <start_time> <stop_time> <file_format> [--use_cache] [--max_retry MAX_RETRY] [-o OUTPUT]
+    metocean-cli download <product> <lat> <lon> <start_time> <stop_time> <file_format> [--no_cache] [--max_retry MAX_RETRY] [-o OUTPUT]
 
   **Arguments:**
 
@@ -295,7 +297,7 @@ Command Line Interface (CLI) - metocean-cli
   - ``<start_time>``: Start time for data in ISO 8601 format (e.g., ``"2023-01-01"``).
   - ``<stop_time>``: Stop time for data in ISO 8601 format (e.g., ``"2023-01-02"``).
   - ``<file_format>``: Format of the output file: ``"csv"``, ``"netcdf"``, or ``"both"``.
-  - ``--use_cache``: Optional flag to use cached data if available. Default is ``True``.
+  - ``--no_cache``: Optional flag to removed the cached data at the end of the processing.
   - ``--max_retry MAX_RETRY``: Optional argument to specify the maximum number of retry attempts for the download. Default is ``5``.
   - ``-o OUTPUT``, ``--output OUTPUT``: Path to the output file where the downloaded data will be saved.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to metocean-api's documentation!
-=====================================
+========================================
 
 **metocean-api**  is a Python tool designed to extract time series of metocean (meteorological and oceanographic) data from various sources, including global, regional, and coastal hindcasts and reanalysis.
 The extracted data can be saved in CSV format or NetCDF for further analysis and usage.
@@ -270,6 +270,63 @@ To combine several csv-files produced by **metocean-api**:
    df = ts.ts_mod.combine_data(list_files=['NORA3_wind_sub_lon1.32_lat53.324_20210101_20210131.csv',
                                            'NORA3_atm_sub_lon1.32_lat53.324_20210101_20210331.csv'],
                                    output_file='combined_NORA3_lon1.32_lat53.324.csv')  
+
+
+
+Command Line Interface (CLI) - metocean-cli
+===========================================
+
+**Download Command**
+
+
+  The ``download`` command is used to download metocean data for a specified product, location, and time range.
+
+  **Usage:**
+
+  .. code-block:: bash
+
+    metocean-cli download <product> <lat> <lon> <start_time> <stop_time> <file_format> [--use_cache] [--max_retry MAX_RETRY] [-o OUTPUT]
+
+  **Arguments:**
+
+  - ``<product>``: Name of the product to download.
+  - ``<lat>``: Latitude of the location.
+  - ``<lon>``: Longitude of the location.
+  - ``<start_time>``: Start time for data in ISO 8601 format (e.g., ``"2023-01-01"``).
+  - ``<stop_time>``: Stop time for data in ISO 8601 format (e.g., ``"2023-01-02"``).
+  - ``<file_format>``: Format of the output file: ``"csv"``, ``"netcdf"``, or ``"both"``.
+  - ``--use_cache``: Optional flag to use cached data if available. Default is ``True``.
+  - ``--max_retry MAX_RETRY``: Optional argument to specify the maximum number of retry attempts for the download. Default is ``5``.
+  - ``-o OUTPUT``, ``--output OUTPUT``: Path to the output file where the downloaded data will be saved.
+
+  **Example:**
+
+  .. code-block:: bash
+
+    metocean-cli download NORA3_offshore_wind 54.01 6.58 "2023-01-01" "2023-01-02" csv
+
+**Combine Command**
+
+  The ``combine`` command is used to combine multiple metocean data files into a single output file.
+
+  **Usage:**
+
+  .. code-block:: bash
+
+    metocean-cli combine <files>... -o OUTPUT
+
+  **Arguments:**
+
+  - ``<files>...``: List of file paths to combine. You can specify multiple files separated by spaces.
+  - ``-o OUTPUT``, ``--output OUTPUT``: Path to the output file where the combined data will be saved.
+
+  **Example:**
+
+  .. code-block:: bash
+
+    metocean-cli combine 'NORA3_wind_sub_lon1.32_lat53.324_20210101_20210131.csv' 'NORA3_atm_sub_lon1.32_lat53.324_20210101_20210331.csv' -o combined.csv
+
+
 
 .. toctree::
    :maxdepth: 2

--- a/metocean_api/cli/metocean_cli.py
+++ b/metocean_api/cli/metocean_cli.py
@@ -141,7 +141,7 @@ def main():
 
     if args.command == 'download':
         download(args.product, args.lat, args.lon, args.start_time, args.stop_time,
-                 args.file_format, not args.clear_cache, args.max_retry, args.output)
+                 args.file_format, not args.no_cache, args.max_retry, args.output)
     elif args.command == 'combine':
         combine(args.files, args.output)
     else:

--- a/metocean_api/cli/metocean_cli.py
+++ b/metocean_api/cli/metocean_cli.py
@@ -33,17 +33,17 @@ def download(product: str, lat: float, lon: float, start_time: str, stop_time: s
     print(f"Use cache: {use_cache}, Max retry: {max_retry}")
 
     file_format_options = {
-        'csv': False,
-        'netcdf': False
+        'save_csv': False,
+        'save_nc': False
     }
 
     if file_format == 'csv':
-        file_format_options['csv'] = True
+        file_format_options['save_csv'] = True
     elif file_format == 'netcdf':
-        file_format_options['netcdf'] = True
+        file_format_options['save_nc'] = True
     elif file_format == 'both':
-        file_format_options['csv'] = True
-        file_format_options['netcdf'] = True
+        file_format_options['save_csv'] = True
+        file_format_options['save_nc'] = True
 
     retry_count = 0
     success = False

--- a/metocean_api/cli/metocean_cli.py
+++ b/metocean_api/cli/metocean_cli.py
@@ -123,8 +123,8 @@ def main():
     download_parser.add_argument('stop_time', type=str, help='Stop time for data in ISO 8601 format')
     download_parser.add_argument('file_format', type=str, choices=['csv', 'netcdf', 'both'],
                                  help='Format of the output file: "csv", "netcdf", or "both"')
-    download_parser.add_argument('--use_cache', action='store_true', default=True,
-                                 help='Use cached data if available')
+    download_parser.add_argument('--no_cache', default=False,
+                                 help='Clear cached data at the end of the processing - not recommanded in case of faillure or large dataset')
     download_parser.add_argument('--max_retry', type=int, default=5,
                                  help='Maximum number of retry attempts for the download')
     download_parser.add_argument('-o', '--output', type=str, default=None, required=False,
@@ -141,7 +141,7 @@ def main():
 
     if args.command == 'download':
         download(args.product, args.lat, args.lon, args.start_time, args.stop_time,
-                 args.file_format, args.use_cache, args.max_retry, args.output)
+                 args.file_format, not args.clear_cache, args.max_retry, args.output)
     elif args.command == 'combine':
         combine(args.files, args.output)
     else:

--- a/metocean_api/ts/ts_mod.py
+++ b/metocean_api/ts/ts_mod.py
@@ -3,8 +3,10 @@ import pandas as pd
 import numpy as np
 from .internal import products
 from .internal.aux_funcs import read_commented_lines
+from typing import Optional, List
 
-def combine_data(list_files, output_file=False):
+
+def combine_data(list_files: List[str], output_file: Optional[str] = None):
     for i in range(len(list_files)):
         df = pd.read_csv(list_files[i], comment="#", index_col=0, parse_dates=True)
         top_header = read_commented_lines(list_files[i])

--- a/scripts/download_cli.py
+++ b/scripts/download_cli.py
@@ -1,0 +1,77 @@
+import argparse
+import sys
+
+from metocean_api import ts
+
+
+def download(product : str, 
+             lat : float, lon : float,
+             start_time : str, stop_time : str, file_format : str,
+             use_cache : bool =True, max_retry : int = 5):
+    
+    print(f"Downloading {product} data from {start_time} to {stop_time} at ({lat}, {lon}) in {file_format} format.")
+    print(f"Use cache: {use_cache}, Max retry: {max_retry}")
+
+
+    file_format_options = {
+        'csv': False,
+        'netcdf': False
+    }
+
+    if file_format == 'csv':
+        file_format_options['csv'] = True
+    elif file_format == 'netcdf':
+        file_format_options['netcdf'] = True
+    elif file_format == 'both':
+        file_format_options['csv'] = True
+        file_format_options['netcdf'] = True
+
+    try:
+        df_ts = ts.TimeSeries(lon=lon, lat=lat,
+                    start_time=start_time, end_time=start_time ,
+                    product=product, datafile=)
+        
+        df_ts.import_data(**file_format_options, use_cache=use_cache)
+
+
+
+
+
+def combine(files : list[str], output_file : str):
+    # Your combine logic here
+    print(f"Combining files: {files} into {output_file}")
+    df = ts.ts_mod.combine_data(list_files=files,
+                                output_file=output_file)
+
+def main():
+    parser = argparse.ArgumentParser(description='Metocean-api CLI')
+    subparsers = parser.add_subparsers(dest='command', help='Sub-command help')
+
+    # Download command
+    download_parser = subparsers.add_parser('download', help='Download metocean data')
+    download_parser.add_argument('product', type=str, help='Product to download')
+    download_parser.add_argument('lat', type=float, help='Latitude')
+    download_parser.add_argument('lon', type=float, help='Longitude')
+    download_parser.add_argument('start_time', type=str, help='Start time in ISO 8601 format')
+    download_parser.add_argument('stop_time', type=str, help='Stop time in ISO 8601 format')
+    download_parser.add_argument('file_format', type=str, choices=['csv', 'netcdf', 'both'], help='File format')
+    download_parser.add_argument('--use_cache', type=bool, default=True, help='Use cache')
+    download_parser.add_argument('--max_retry', type=int, default=5, help='Maximum number of retries')
+    download_parser.add_argument('-o', '--output', type=str, required=True, help='Output file')
+
+    # Combine command
+    combine_parser = subparsers.add_parser('combine', help='Combine multiple files')
+    combine_parser.add_argument('files', type=str, nargs='+', help='Files to combine')
+    combine_parser.add_argument('-o', '--output', type=str, required=True, help='Output file')
+
+    args = parser.parse_args()
+
+    if args.command == 'download':
+        download(args.product, args.lat, args.lon, args.start_time, args.stop_time, args.file_format, args.use_cache, args.max_retry, args.output)
+    elif args.command == 'combine':
+        combine(args.files, args.output)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,12 @@ setuptools.setup(
     include_package_data = True,
     setup_requires = ['setuptools_scm'],
     tests_require = ['pytest','pytest-cov'],
-    scripts = []
+    scripts = [],
+    entry_points={
+        'console_scripts': [
+            'metocean-cli=metocean_api.cli.metocean_cli:main',
+        ],
+    },
 )
 
 


### PR DESCRIPTION
This PR adds a command-line interface to the MetOcean API with two main commands:

```bash
metocean-cli download <product> <lat> <lon> <start_time> <stop_time> <file_format> [--no_cache] [--max_retry MAX_RETRY] [-o OUTPUT]
```

```bash
metocean-cli combine <files>... -o OUTPUT
```

The documentation has been updated, and the commands are documented. I haven't written tests for it as it basically only uses the main components of the metocean-api. For the download, a retry function is added to automatically restart in case of an error.
